### PR TITLE
Fix loading of vectorizer configs

### DIFF
--- a/aa2codon_code.py
+++ b/aa2codon_code.py
@@ -143,13 +143,17 @@ from CAI import CAI
 
 ## Stored vectorize layers
 from_disk = pickle.load(open("/content/aa2codon/aa2id.pkl", "rb"))
-aa2id = tf.keras.layers.TextVectorization.from_config(from_disk['config'])
+config = from_disk['config']
+config.pop('batch_input_shape', None)
+aa2id = tf.keras.layers.TextVectorization.from_config(config)
 
 aa2id.adapt(tf.data.Dataset.from_tensor_slices(["xyz"]))
 aa2id.set_weights(from_disk['weights'])
 
 from_disk = pickle.load(open("/content/aa2codon/codon2id.pkl", "rb"))
-codon2id = tf.keras.layers.TextVectorization.from_config(from_disk['config'])
+config = from_disk['config']
+config.pop('batch_input_shape', None)
+codon2id = tf.keras.layers.TextVectorization.from_config(config)
 
 codon2id.adapt(tf.data.Dataset.from_tensor_slices(["xyz"]))
 codon2id.set_weights(from_disk['weights'])


### PR DESCRIPTION
## Summary
- fix reconstruction of TextVectorization layers when loading pickles

## Testing
- `pytest -q`
- `python -m py_compile aa2codon_code.py` *(fails: SyntaxError due to notebook commands)*

------
https://chatgpt.com/codex/tasks/task_e_6867a5126f508327a92eabec87ac25ba