### PR TITLE
Handle obsolete field in aa2id/codon2id configs

### DIFF
--- a/aa2codon_code.py
+++ b/aa2codon_code.py
@@ -35,13 +35,21 @@ from CAI import CAI
 
 ## Stored vectorize layers
 from_disk = pickle.load(open("/content/aa2codon/aa2id.pkl", "rb"))
-aa2id = tf.keras.layers.TextVectorization.from_config(from_disk['config'])
+# The vectorization layers were saved with an older TensorFlow version whose
+# config included the deprecated ``batch_input_shape`` argument.  Newer Keras
+# versions no longer accept this argument so we remove it before constructing
+# the layer.
+config = dict(from_disk['config'])
+config.pop('batch_input_shape', None)
+aa2id = tf.keras.layers.TextVectorization.from_config(config)
 
 aa2id.adapt(tf.data.Dataset.from_tensor_slices(["xyz"]))
 aa2id.set_weights(from_disk['weights'])
 
 from_disk = pickle.load(open("/content/aa2codon/codon2id.pkl", "rb"))
-codon2id = tf.keras.layers.TextVectorization.from_config(from_disk['config'])
+config = dict(from_disk['config'])
+config.pop('batch_input_shape', None)
+codon2id = tf.keras.layers.TextVectorization.from_config(config)
 
 codon2id.adapt(tf.data.Dataset.from_tensor_slices(["xyz"]))
 codon2id.set_weights(from_disk['weights'])


### PR DESCRIPTION
## Summary
- remove `batch_input_shape` from stored TextVectorization configs before calling `from_config`

## Testing
- `pip install numpy`


------
https://chatgpt.com/codex/tasks/task_e_6867ac2b0aa483278889c1dba0913318