### PR TITLE
Enable GPU inference optimizations and compile model call

### DIFF
--- a/aa2codon_code.py
+++ b/aa2codon_code.py
@@ -31,6 +31,14 @@ import plotly.express as px
 
 import pickle
 
+gpus = tf.config.list_physical_devices("GPU")
+if gpus:
+  tf.config.experimental.enable_tensor_float_32_execution(True)
+  tf.config.optimizer.set_jit(True)
+  tf.keras.mixed_precision.set_global_policy("mixed_float16")
+  for gpu in gpus:
+    tf.config.experimental.set_memory_growth(gpu, True)
+
 from CAI import CAI
 
 ## Stored vectorize layers
@@ -76,6 +84,7 @@ print("Loading the trained model...")
 reloaded = tf.saved_model.load(f'{sijainti}')
 # Print a message to indicate that the model is being loaded
 print("Ladattu:" , reloaded)
+infer = tf.function(reloaded.__call__)
 
 # Inference
 
@@ -178,7 +187,7 @@ seq = input("Provide a sequence: Example of a calid sequence: 'atgctattttag' (wi
 
 # Inference
 aa_seq, codon_seq = pair_provider(seq)
-prediction, tokens, attention_weights = reloaded(aa_seq)
+prediction, tokens, attention_weights = infer(aa_seq)
 predicted_codons = decode_codons(prediction)
 predicted_aas = [str(Seq(x).translate()) for x in predicted_codons[1:-1]]
 predicted_aas.insert(0, "[START]")


### PR DESCRIPTION
### Motivation
- Improve inference throughput and latency when a GPU (e.g., A100) is available by enabling hardware and runtime optimizations.  
- Reduce Python-side overhead for repeated model calls by compiling the model entry point.  
- Allow models to use reduced precision safely for faster computation via mixed precision.  
- Avoid excessive GPU memory pre-allocation by enabling memory growth on detected devices.  

### Description
- Detects available GPUs with `tf.config.list_physical_devices("GPU")` and applies GPU-specific settings when present.  
- Enables TF32 execution via `tf.config.experimental.enable_tensor_float_32_execution(True)` and XLA JIT with `tf.config.optimizer.set_jit(True)`.  
- Sets the global mixed precision policy to `mixed_float16` with `tf.keras.mixed_precision.set_global_policy("mixed_float16")` and enables per-GPU memory growth.  
- Wraps the saved model call in a compiled `tf.function` by creating `infer = tf.function(reloaded.__call__)` and updates calls from `reloaded(...)` to `infer(...)`.  

### Testing
- No automated unit or integration tests were invoked as part of this change.  
- No CI jobs were executed during the rollout.  
- Runtime verification (interactive/manual) was not performed by automated scripts.  
- Static checks/linters were not reported as run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a769d56d88327b886ad40eb6f804b)