### PR TITLE
Run TextVectorization on CPU in prepare_batch to avoid GPU resource errors

### DIFF
--- a/Codon_optimizer_train_tf219.ipynb
+++ b/Codon_optimizer_train_tf219.ipynb
@@ -237,8 +237,9 @@
    "outputs": [],
    "source": [
     "def prepare_batch(aas, codons):\n",
-    "    aas = aa2id(aas)\n",
-    "    codons = codon2id(codons)\n",
+    "    with tf.device(\"/CPU:0\"):\n",
+    "        aas = aa2id(aas)\n",
+    "        codons = codon2id(codons)\n",
     "    codons_inputs = codons[:, :-1]\n",
     "    codons_labels = codons[:, 1:]\n",
     "    return (aas, codons_inputs), codons_labels\n",


### PR DESCRIPTION
### Motivation
- Prevent GPU/CPU resource mismatch errors observed when `TextVectorization` is invoked inside dataset `map` operations.
- Limit the change to only the CPU/GPU resource issue without altering batching or model logic.

### Description
- Modified `Codon_optimizer_train_tf219.ipynb` to wrap the `aa2id(aas)` and `codon2id(codons)` calls in `prepare_batch` with `with tf.device("/CPU:0"):`.
- Kept the rest of `prepare_batch` logic unchanged, including creation of `codons_inputs` and `codons_labels` and the `make_batches` pipeline.
- This forces the `TextVectorization` operations to execute on the CPU to avoid allocating GPU resources during dataset mapping.

### Testing
- No automated tests were executed for this change.
- The notebook cell containing `prepare_batch` was updated but not re-executed as part of this rollout.
- No additional CI or runtime validation was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8bcc9b188327a9347d21ebef1ee2)