### PR TITLE
Pre-vectorize datasets to avoid GPU/CPU resource mismatch

### DIFF
--- a/Codon_optimizer_train_tf219.ipynb
+++ b/Codon_optimizer_train_tf219.ipynb
@@ -218,13 +218,17 @@
     "train_aas, val_aas = makeds(aas)\n",
     "train_codons, val_codons = makeds(codons)\n",
     "\n",
-    "tds = tf.data.Dataset.from_tensor_slices((train_aas, train_codons))\n",
-    "vds = tf.data.Dataset.from_tensor_slices((val_aas, val_codons))\n",
     "\n",
     "aa2id = tf.keras.layers.TextVectorization(standardize=None, split='whitespace')\n",
     "aa2id.adapt(tf.constant(aas))\n",
     "codon2id = tf.keras.layers.TextVectorization(standardize=None, split='whitespace')\n",
-    "codon2id.adapt(tf.constant(codons))\n"
+    "codon2id.adapt(tf.constant(codons))\n",
+    "train_aas_vec = aa2id(tf.constant(train_aas))\n",
+    "train_codons_vec = codon2id(tf.constant(train_codons))\n",
+    "val_aas_vec = aa2id(tf.constant(val_aas))\n",
+    "val_codons_vec = codon2id(tf.constant(val_codons))\n",
+    "tds = tf.data.Dataset.from_tensor_slices((train_aas_vec, train_codons_vec))\n",
+    "vds = tf.data.Dataset.from_tensor_slices((val_aas_vec, val_codons_vec))\n"
    ],
    "id": "VsKDoZ6-eVEt"
   },
@@ -237,8 +241,6 @@
    "outputs": [],
    "source": [
     "def prepare_batch(aas, codons):\n",
-    "    aas = aa2id(aas)\n",
-    "    codons = codon2id(codons)\n",
     "    codons_inputs = codons[:, :-1]\n",
     "    codons_labels = codons[:, 1:]\n",
     "    return (aas, codons_inputs), codons_labels\n",


### PR DESCRIPTION
### Motivation
- Avoid `InvalidArgumentError` caused by `TextVectorization` being executed inside mapped functions while training on GPU, which triggers CPU/GPU resource access conflicts.
- Move heavy vectorization work out of the `map` pipeline to prevent runtime device-placement issues when calling `aa2id`/`codon2id` from `prepare_batch`.
- Implement a minimal change that keeps batching and model logic unchanged while eliminating cross-device access during dataset mapping.

### Description
- Precompute `train_aas_vec`, `train_codons_vec`, `val_aas_vec`, and `val_codons_vec` after calling `aa2id.adapt` and `codon2id.adapt`.
- Construct datasets with `tf.data.Dataset.from_tensor_slices` from the pre-vectorized tensors (`tds` and `vds`).
- Remove `aa2id`/`codon2id` calls from `prepare_batch` so it operates on already-vectorized inputs.
- Applied the changes to the notebook file `Codon_optimizer_train_tf219.ipynb`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8bcc9b188327a9347d21ebef1ee2)