### PR TITLE
Remove CPU pinning in training batch preparation

### DIFF
--- a/Codon_optimizer_train_tf219.ipynb
+++ b/Codon_optimizer_train_tf219.ipynb
@@ -237,9 +237,8 @@
    "outputs": [],
    "source": [
     "def prepare_batch(aas, codons):\n",
-    "    with tf.device(\"/CPU:0\"):\n",
-    "        aas = aa2id(aas)\n",
-    "        codons = codon2id(codons)\n",
+    "    aas = aa2id(aas)\n",
+    "    codons = codon2id(codons)\n",
     "    codons_inputs = codons[:, :-1]\n",
     "    codons_labels = codons[:, 1:]\n",
     "    return (aas, codons_inputs), codons_labels\n",


### PR DESCRIPTION
### Motivation
- The `prepare_batch` function enforced `tf.device("/CPU:0")` for `aa2id` and `codon2id`, which can cause GPU/CPU resource conflicts.
- Allowing `TextVectorization` mappings to run on the default device improves compatibility with GPU training and `tf.data` optimizations.

### Description
- Removed the `with tf.device("/CPU:0")` block inside `prepare_batch` so `aa2id` and `codon2id` are called directly.
- Updated the notebook file `Codon_optimizer_train_tf219.ipynb` to reflect the change to `prepare_batch`.
- Preserved the existing `tf.data` pipeline that uses `shuffle`, `batch`, `map(prepare_batch, tf.data.AUTOTUNE)`, and `prefetch`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a900c5df083278130451dc1dc1e44)