### PR TITLE
Add GPU-safe TensorFlow 2.19 trainer notebook

### DIFF
--- a/Codon_optimizer_train_tf219_gpu.ipynb
+++ b/Codon_optimizer_train_tf219_gpu.ipynb
@@ -1,0 +1,777 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ICCwTzJjeVEp"
+   },
+   "source": [
+    "# Codon optimizer training (TensorFlow 2.19+)\n",
+    "This notebook trains a codon optimizer Transformer using TensorFlow 2.19+.\n",
+    "It expects CDS FASTA files in `Genomes/`. Update paths as needed.\n"
+   ],
+   "id": "ICCwTzJjeVEp"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "pYSE6nJveVEq"
+   },
+   "outputs": [],
+   "source": [
+    "# Optional: install deps in Colab or a clean environment\n",
+    "!pip install \"tensorflow==2.19.*\" \"tensorflow-text==2.19.*\" biopython \"numpy<2.1\" pandas\n"
+   ],
+   "id": "pYSE6nJveVEq"
+  },
+  {
+   "cell_type": "code",
+   "source": [
+    "!git clone https://github.com/pyypyyy/aa2codon.git"
+   ],
+   "metadata": {
+    "id": "hZ6HFF6Gfwgb"
+   },
+   "id": "hZ6HFF6Gfwgb",
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wmoMek0ZeVEr"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "from pathlib import Path\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import tensorflow as tf\n",
+    "from Bio import SeqIO\n",
+    "from Bio.Seq import Seq\n",
+    "from tqdm.notebook import tqdm\n"
+   ],
+   "id": "wmoMek0ZeVEr"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Runtime checks for GPU compatibility\n",
+    "print(\"TensorFlow:\", tf.__version__)\n",
+    "gpus = tf.config.list_physical_devices(\"GPU\")\n",
+    "print(\"GPUs:\", gpus)\n",
+    "for gpu in gpus:\n",
+    "    try:\n",
+    "        tf.config.experimental.set_memory_growth(gpu, True)\n",
+    "    except Exception as exc:\n",
+    "        print(\"Could not set memory growth:\", exc)\n",
+    "\n",
+    "# Ensure graph execution uses stable dtypes\n",
+    "tf.config.run_functions_eagerly(False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "_MzT21tyeVEr"
+   },
+   "source": [
+    "## Data preparation\n"
+   ],
+   "id": "_MzT21tyeVEr"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4_p6th6_eVEr"
+   },
+   "outputs": [],
+   "source": [
+    "def whitespace_separate(my_string, n):\n",
+    "    return \" \".join(my_string[i:i+n] for i in range(0, len(my_string), n))\n",
+    "\n",
+    "def process_cds(directory, max_seqs=7000):\n",
+    "    \"\"\"\n",
+    "    Parse CDS FASTA files, filter pseudogenes and sequences not divisible by 3.\n",
+    "    Returns a dataframe with codon and amino-acid sequences.\n",
+    "    \"\"\"\n",
+    "    files = [f for f in os.listdir(directory) if not f.startswith('.')]\n",
+    "    cds_proteins = []\n",
+    "    for file in tqdm(files):\n",
+    "        fasta_file = os.path.join(directory, file)\n",
+    "        if not os.path.isfile(fasta_file):\n",
+    "            continue\n",
+    "        records = list(SeqIO.parse(fasta_file, \"fasta\"))\n",
+    "        skipped = 0\n",
+    "        accepted = 0\n",
+    "        for rec in tqdm(records, total=len(records)):\n",
+    "            if len(rec.seq) % 3 != 0:\n",
+    "                skipped += 1\n",
+    "                continue\n",
+    "            if \"pseudogene\" in rec.description:\n",
+    "                skipped += 1\n",
+    "                continue\n",
+    "            if accepted >= max_seqs:\n",
+    "                continue\n",
+    "            protein = rec.seq.translate()\n",
+    "            cds_proteins.append((file.split(\".\")[0], str(rec.seq), str(protein)))\n",
+    "            accepted += 1\n",
+    "        print(f\"{file}: skipped {skipped}, accepted {accepted}\")\n",
+    "\n",
+    "    df = pd.DataFrame(cds_proteins, columns=[\"filename\", \"gene_sequence\", \"protein_sequence\"])\n",
+    "    df[\"gene_sequence\"] = df[\"gene_sequence\"].apply(lambda x: whitespace_separate(x, 3))\n",
+    "    df[\"protein_sequence\"] = df[\"protein_sequence\"].apply(lambda x: whitespace_separate(x, 1))\n",
+    "\n",
+    "    df[\"gene_sequence\"] = df[\"gene_sequence\"].str.split()\n",
+    "    df[\"protein_sequence\"] = df[\"protein_sequence\"].str.split()\n",
+    "\n",
+    "    if len(files) > 1:\n",
+    "        for i in range(len(df)):\n",
+    "            df.at[i, \"gene_sequence\"].insert(0, f\"<{df.at[i, 'filename']}>\")\n",
+    "            df.at[i, \"protein_sequence\"].insert(0, f\"<{df.at[i, 'filename']}>\")\n",
+    "\n",
+    "    df[\"gene_sequence\"] = df[\"gene_sequence\"].str.join(' ')\n",
+    "    df[\"protein_sequence\"] = df[\"protein_sequence\"].str.join(' ')\n",
+    "    return df.drop(columns=[\"filename\"])\n"
+   ],
+   "id": "4_p6th6_eVEr"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VhuT6cMieVEs"
+   },
+   "outputs": [],
+   "source": [
+    "def shorten(seq, max_length):\n",
+    "    seq2 = []\n",
+    "    for i in tqdm(seq):\n",
+    "        if len(i) > max_length:\n",
+    "            organism = i[0]\n",
+    "            first = i[: len(i) // 2]\n",
+    "            second = i[len(i) // 2 :]\n",
+    "            second.insert(0, organism)\n",
+    "            seq2.extend([first, second])\n",
+    "        else:\n",
+    "            seq2.append(i)\n",
+    "    return seq2\n"
+   ],
+   "id": "VhuT6cMieVEs"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "C7rYvnD4eVEs"
+   },
+   "outputs": [],
+   "source": [
+    "data_path = Path('/content/aa2codon/Genomes')\n",
+    "df = process_cds(str(data_path), max_seqs=7000)\n",
+    "print(df.head())\n"
+   ],
+   "id": "C7rYvnD4eVEs"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Fxi-8isseVEs"
+   },
+   "outputs": [],
+   "source": [
+    "max_length = 150\n",
+    "codons = [s.split(' ') for s in df['gene_sequence'].tolist()]\n",
+    "aas = [s.split(' ') for s in df['protein_sequence'].tolist()]\n",
+    "\n",
+    "while any(len(x) > max_length for x in codons):\n",
+    "    codons = shorten(codons, max_length)\n",
+    "while any(len(x) > max_length for x in aas):\n",
+    "    aas = shorten(aas, max_length)\n",
+    "\n",
+    "for i in codons:\n",
+    "    i.insert(0, '<start>')\n",
+    "    i.append('<end>')\n",
+    "for i in aas:\n",
+    "    i.insert(0, '<start>')\n",
+    "    i.append('<end>')\n",
+    "\n",
+    "codons = [' '.join(i) for i in codons]\n",
+    "aas = [' '.join(i) for i in aas]\n"
+   ],
+   "id": "Fxi-8isseVEs"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "QAtnHjGIeVEt"
+   },
+   "source": [
+    "## Vectorization & datasets\n"
+   ],
+   "id": "QAtnHjGIeVEt"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "VsKDoZ6-eVEt"
+   },
+   "outputs": [],
+   "source": [
+    "def makeds(seqs):\n",
+    "    num_val_samples = int(0.07 * len(seqs))\n",
+    "    num_train_samples = len(seqs) - 2 * num_val_samples\n",
+    "    train_pairs = seqs[:num_train_samples]\n",
+    "    val_pairs = seqs[num_train_samples:]\n",
+    "    return train_pairs, val_pairs\n",
+    "\n",
+    "train_aas, val_aas = makeds(aas)\n",
+    "train_codons, val_codons = makeds(codons)\n",
+    "\n",
+    "tds = tf.data.Dataset.from_tensor_slices((train_aas, train_codons))\n",
+    "vds = tf.data.Dataset.from_tensor_slices((val_aas, val_codons))\n",
+    "\n",
+    "aa2id = tf.keras.layers.TextVectorization(\n",
+    "    standardize=None, split=\"whitespace\", output_mode=\"int\", output_dtype=tf.int32\n",
+    ")\n",
+    "aa2id.adapt(tf.constant(aas))\n",
+    "codon2id = tf.keras.layers.TextVectorization(\n",
+    "    standardize=None, split=\"whitespace\", output_mode=\"int\", output_dtype=tf.int32\n",
+    ")\n",
+    "codon2id.adapt(tf.constant(codons))\n"
+   ],
+   "id": "VsKDoZ6-eVEt"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oc8RR22QeVEu"
+   },
+   "outputs": [],
+   "source": [
+    "def prepare_batch(aas, codons):\n",
+    "    aas = tf.cast(aa2id(aas), tf.int32)\n",
+    "    codons = tf.cast(codon2id(codons), tf.int32)\n",
+    "    codons_inputs = codons[:, :-1]\n",
+    "    codons_labels = codons[:, 1:]\n",
+    "    return (aas, codons_inputs), codons_labels\n",
+    "\n",
+    "def make_batches(ds, buffer_size=100000, batch_size=64):\n",
+    "    return (\n",
+    "        ds.shuffle(buffer_size)\n",
+    "        .map(prepare_batch, tf.data.AUTOTUNE)\n",
+    "        .padded_batch(\n",
+    "            batch_size,\n",
+    "            padded_shapes=(([None], [None]), [None]),\n",
+    "            padding_values=((0, 0), 0),\n",
+    "            drop_remainder=True,\n",
+    "        )\n",
+    "        .prefetch(buffer_size=tf.data.AUTOTUNE)\n",
+    "    )\n"
+   ],
+   "id": "oc8RR22QeVEu"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "CP7S6IBfeVEu"
+   },
+   "source": [
+    "## Model\n"
+   ],
+   "id": "CP7S6IBfeVEu"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "LZSwg1ZEeVEu"
+   },
+   "outputs": [],
+   "source": [
+    "def positional_encoding(length, depth):\n",
+    "    depth = depth // 2\n",
+    "    positions = tf.range(length, dtype=tf.float32)[:, tf.newaxis]\n",
+    "    depths = tf.range(depth, dtype=tf.float32)[tf.newaxis, :] / tf.cast(depth, tf.float32)\n",
+    "    angle_rates = 1.0 / tf.pow(10000.0, depths)\n",
+    "    angle_rads = positions * angle_rates\n",
+    "    pos_encoding = tf.concat([tf.sin(angle_rads), tf.cos(angle_rads)], axis=-1)\n",
+    "    return tf.cast(pos_encoding, dtype=tf.float32)\n",
+    "\n",
+    "class PositionalEmbedding(tf.keras.layers.Layer):\n",
+    "    def __init__(self, vocab_size, d_model):\n",
+    "        super().__init__()\n",
+    "        self.d_model = d_model\n",
+    "        self.embedding = tf.keras.layers.Embedding(vocab_size, d_model, mask_zero=True)\n",
+    "        self.pos_encoding = positional_encoding(length=2048, depth=d_model)\n",
+    "\n",
+    "    def compute_mask(self, *args, **kwargs):\n",
+    "        return self.embedding.compute_mask(*args, **kwargs)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        length = tf.shape(x)[1]\n",
+    "        x = self.embedding(x)\n",
+    "        x *= tf.math.sqrt(tf.cast(self.d_model, tf.float32))\n",
+    "        x = x + self.pos_encoding[tf.newaxis, :length, :]\n",
+    "        return x\n"
+   ],
+   "id": "LZSwg1ZEeVEu"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "nxgy7A8_eVEu"
+   },
+   "outputs": [],
+   "source": [
+    "class BaseAttention(tf.keras.layers.Layer):\n",
+    "    def __init__(self, **kwargs):\n",
+    "        super().__init__()\n",
+    "        self.mha = tf.keras.layers.MultiHeadAttention(**kwargs)\n",
+    "        self.layernorm = tf.keras.layers.LayerNormalization()\n",
+    "        self.add = tf.keras.layers.Add()\n",
+    "\n",
+    "class CrossAttention(BaseAttention):\n",
+    "    def call(self, x, context):\n",
+    "        attn_output, attn_scores = self.mha(\n",
+    "            query=x, key=context, value=context, return_attention_scores=True\n",
+    "        )\n",
+    "        self.last_attn_scores = attn_scores\n",
+    "        x = self.add([x, attn_output])\n",
+    "        x = self.layernorm(x)\n",
+    "        return x\n",
+    "\n",
+    "class GlobalSelfAttention(BaseAttention):\n",
+    "    def call(self, x):\n",
+    "        attn_output = self.mha(query=x, value=x, key=x)\n",
+    "        x = self.add([x, attn_output])\n",
+    "        x = self.layernorm(x)\n",
+    "        return x\n",
+    "\n",
+    "class CausalSelfAttention(BaseAttention):\n",
+    "    def call(self, x):\n",
+    "        attn_output = self.mha(query=x, value=x, key=x, use_causal_mask=True)\n",
+    "        x = self.add([x, attn_output])\n",
+    "        x = self.layernorm(x)\n",
+    "        return x\n",
+    "\n",
+    "class FeedForward(tf.keras.layers.Layer):\n",
+    "    def __init__(self, d_model, dff, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.seq = tf.keras.Sequential([\n",
+    "            tf.keras.layers.Dense(dff, activation='relu'),\n",
+    "            tf.keras.layers.Dense(d_model),\n",
+    "            tf.keras.layers.Dropout(dropout_rate),\n",
+    "        ])\n",
+    "        self.add = tf.keras.layers.Add()\n",
+    "        self.layer_norm = tf.keras.layers.LayerNormalization()\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        x = self.add([x, self.seq(x)])\n",
+    "        x = self.layer_norm(x)\n",
+    "        return x\n"
+   ],
+   "id": "nxgy7A8_eVEu"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NY72aQZeeVEu"
+   },
+   "outputs": [],
+   "source": [
+    "class EncoderLayer(tf.keras.layers.Layer):\n",
+    "    def __init__(self, *, d_model, num_heads, dff, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.self_attention = GlobalSelfAttention(\n",
+    "            num_heads=num_heads, key_dim=d_model, dropout=dropout_rate\n",
+    "        )\n",
+    "        self.ffn = FeedForward(d_model, dff)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        x = self.self_attention(x)\n",
+    "        x = self.ffn(x)\n",
+    "        return x\n",
+    "\n",
+    "class Encoder(tf.keras.layers.Layer):\n",
+    "    def __init__(self, *, num_layers, d_model, num_heads, dff, vocab_size, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.d_model = d_model\n",
+    "        self.num_layers = num_layers\n",
+    "        self.pos_embedding = PositionalEmbedding(vocab_size=vocab_size, d_model=d_model)\n",
+    "        self.enc_layers = [\n",
+    "            EncoderLayer(d_model=d_model, num_heads=num_heads, dff=dff, dropout_rate=dropout_rate)\n",
+    "            for _ in range(num_layers)\n",
+    "        ]\n",
+    "        self.dropout = tf.keras.layers.Dropout(dropout_rate)\n",
+    "\n",
+    "    def call(self, x):\n",
+    "        x = self.pos_embedding(x)\n",
+    "        x = self.dropout(x)\n",
+    "        for i in range(self.num_layers):\n",
+    "            x = self.enc_layers[i](x)\n",
+    "        return x\n",
+    "\n",
+    "class DecoderLayer(tf.keras.layers.Layer):\n",
+    "    def __init__(self, *, d_model, num_heads, dff, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.causal_self_attention = CausalSelfAttention(\n",
+    "            num_heads=num_heads, key_dim=d_model, dropout=dropout_rate\n",
+    "        )\n",
+    "        self.cross_attention = CrossAttention(\n",
+    "            num_heads=num_heads, key_dim=d_model, dropout=dropout_rate\n",
+    "        )\n",
+    "        self.ffn = FeedForward(d_model, dff)\n",
+    "\n",
+    "    def call(self, x, context):\n",
+    "        x = self.causal_self_attention(x=x)\n",
+    "        x = self.cross_attention(x=x, context=context)\n",
+    "        self.last_attn_scores = self.cross_attention.last_attn_scores\n",
+    "        x = self.ffn(x)\n",
+    "        return x\n",
+    "\n",
+    "class Decoder(tf.keras.layers.Layer):\n",
+    "    def __init__(self, *, num_layers, d_model, num_heads, dff, vocab_size, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.d_model = d_model\n",
+    "        self.num_layers = num_layers\n",
+    "        self.pos_embedding = PositionalEmbedding(vocab_size=vocab_size, d_model=d_model)\n",
+    "        self.dropout = tf.keras.layers.Dropout(dropout_rate)\n",
+    "        self.dec_layers = [\n",
+    "            DecoderLayer(d_model=d_model, num_heads=num_heads, dff=dff, dropout_rate=dropout_rate)\n",
+    "            for _ in range(num_layers)\n",
+    "        ]\n",
+    "        self.last_attn_scores = None\n",
+    "\n",
+    "    def call(self, x, context):\n",
+    "        x = self.pos_embedding(x)\n",
+    "        x = self.dropout(x)\n",
+    "        for i in range(self.num_layers):\n",
+    "            x = self.dec_layers[i](x, context)\n",
+    "        self.last_attn_scores = self.dec_layers[-1].last_attn_scores\n",
+    "        return x\n",
+    "\n",
+    "class Transformer(tf.keras.Model):\n",
+    "    def __init__(self, *, num_layers, d_model, num_heads, dff, input_vocab_size, target_vocab_size, dropout_rate=0.1):\n",
+    "        super().__init__()\n",
+    "        self.encoder = Encoder(\n",
+    "            num_layers=num_layers, d_model=d_model, num_heads=num_heads, dff=dff,\n",
+    "            vocab_size=input_vocab_size, dropout_rate=dropout_rate\n",
+    "        )\n",
+    "        self.decoder = Decoder(\n",
+    "            num_layers=num_layers, d_model=d_model, num_heads=num_heads, dff=dff,\n",
+    "            vocab_size=target_vocab_size, dropout_rate=dropout_rate\n",
+    "        )\n",
+    "        self.final_layer = tf.keras.layers.Dense(target_vocab_size)\n",
+    "\n",
+    "    def call(self, inputs):\n",
+    "        context, x = inputs\n",
+    "        context = self.encoder(context)\n",
+    "        x = self.decoder(x, context)\n",
+    "        logits = self.final_layer(x)\n",
+    "        try:\n",
+    "            del logits._keras_mask\n",
+    "        except AttributeError:\n",
+    "            pass\n",
+    "        return logits\n"
+   ],
+   "id": "NY72aQZeeVEu"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wbTeSxP4eVEu"
+   },
+   "source": [
+    "## Training\n"
+   ],
+   "id": "wbTeSxP4eVEu"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "F4HKqaMReVEv"
+   },
+   "outputs": [],
+   "source": [
+    "codon_list = [\n",
+    "    'CTG','GAA','GCG','ATG','AAA','GAT','ATT','GGC','CAG','GTG','GCC',\n",
+    "    'ATC','GGT','ACC','CCG','TTT','CGC','AAC','CGT','GCA','GAC','GTT','GAG','AAT','TTC',\n",
+    "    'AGC','TAT','CAA','GTC','GCT','TGG','ACG','TTG','TTA','CAT','TAC','CTC','CTT','GGG',\n",
+    "    'GTA','AAG','CAC','TCG','ACT','AGT','TCC','TCT','CCA','GGA','TCA',\n",
+    "    'CCT','ACA','TGC','CCC','CGG','TGT','ATA','CTA','CGA','TAA','AGA','AGG','TGA','TAG'\n",
+    "]\n",
+    "\n",
+    "def make_table(keys, values):\n",
+    "    init = tf.lookup.KeyValueTensorInitializer(keys, values)\n",
+    "    return tf.lookup.StaticHashTable(init, default_value=-1)\n",
+    "\n",
+    "aa_table = [str(Seq(codon).translate()) for codon in codon_list]\n",
+    "codon_table = codon_list + ['<start>', '<end>', '[UNK]']\n",
+    "aa_table = aa_table + ['<start>', '<end>', '[UNK]']\n",
+    "\n",
+    "codon_table = [tf.cast(codon2id(codon), tf.int32) for codon in codon_table]\n",
+    "aa_table = [tf.cast(aa2id(aa), tf.int32) for aa in aa_table]\n",
+    "\n",
+    "codon_table.append(tf.convert_to_tensor([0], dtype=tf.int32))\n",
+    "aa_table.append(tf.convert_to_tensor([0], dtype=tf.int32))\n",
+    "\n",
+    "tensor_codon_to_tensor_aa = make_table(codon_table, aa_table)\n"
+   ],
+   "id": "F4HKqaMReVEv"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4C5uNboLeVEv"
+   },
+   "outputs": [],
+   "source": [
+    "def masked_loss(label, pred):\n",
+    "    mask = label != 0\n",
+    "    loss_object = tf.keras.losses.SparseCategoricalCrossentropy(\n",
+    "        from_logits=True, reduction=\"none\"\n",
+    "    )\n",
+    "    loss = loss_object(label, pred)\n",
+    "    mask = tf.cast(mask, dtype=loss.dtype)\n",
+    "    loss *= mask\n",
+    "    denom = tf.maximum(tf.reduce_sum(mask), tf.cast(1.0, loss.dtype))\n",
+    "    return tf.reduce_sum(loss) / denom\n",
+    "\n",
+    "def masked_accuracy(label, pred):\n",
+    "    pred = tf.argmax(pred, axis=2)\n",
+    "    label = tf.cast(label, pred.dtype)\n",
+    "    match = label == pred\n",
+    "    mask = label != 0\n",
+    "    match = match & mask\n",
+    "    match = tf.cast(match, dtype=tf.float32)\n",
+    "    mask = tf.cast(mask, dtype=tf.float32)\n",
+    "    denom = tf.maximum(tf.reduce_sum(mask), 1.0)\n",
+    "    return tf.reduce_sum(match) / denom\n",
+    "\n",
+    "def masked_aa_accuracy(label, pred):\n",
+    "    pred = tf.argmax(pred, axis=2)\n",
+    "    pred = tensor_codon_to_tensor_aa.lookup(pred)\n",
+    "    label = tf.cast(label, pred.dtype)\n",
+    "    label = tensor_codon_to_tensor_aa.lookup(label)\n",
+    "    match = label == pred\n",
+    "    mask = label != 0\n",
+    "    match = match & mask\n",
+    "    match = tf.cast(match, dtype=tf.float32)\n",
+    "    mask = tf.cast(mask, dtype=tf.float32)\n",
+    "    denom = tf.maximum(tf.reduce_sum(mask), 1.0)\n",
+    "    return tf.reduce_sum(match) / denom\n"
+   ],
+   "id": "4C5uNboLeVEv"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "CyaThIhCeVEv"
+   },
+   "outputs": [],
+   "source": [
+    "num_layers = 3\n",
+    "d_model = 128\n",
+    "dff = 256\n",
+    "num_heads = 8\n",
+    "dropout_rate = 0.05\n",
+    "\n",
+    "transformer = Transformer(\n",
+    "    num_layers=num_layers,\n",
+    "    d_model=d_model,\n",
+    "    num_heads=num_heads,\n",
+    "    dff=dff,\n",
+    "    input_vocab_size=len(aa2id.get_vocabulary()),\n",
+    "    target_vocab_size=len(codon2id.get_vocabulary()),\n",
+    "    dropout_rate=dropout_rate,\n",
+    ")\n"
+   ],
+   "id": "CyaThIhCeVEv"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "rMqvA-SLeVEw"
+   },
+   "outputs": [],
+   "source": [
+    "class CustomSchedule(tf.keras.optimizers.schedules.LearningRateSchedule):\n",
+    "    def __init__(self, d_model, warmup_steps=4000):\n",
+    "        super().__init__()\n",
+    "        self.d_model = tf.cast(d_model, tf.float32)\n",
+    "        self.warmup_steps = warmup_steps\n",
+    "\n",
+    "    def __call__(self, step):\n",
+    "        step = tf.cast(step, dtype=tf.float32)\n",
+    "        arg1 = tf.math.rsqrt(step)\n",
+    "        arg2 = step * (self.warmup_steps ** -1.5)\n",
+    "        return tf.math.rsqrt(self.d_model) * tf.math.minimum(arg1, arg2)\n",
+    "\n",
+    "learning_rate = CustomSchedule(d_model)\n",
+    "optimizer = tf.keras.optimizers.Adam(\n",
+    "    learning_rate=learning_rate, beta_1=0.9, beta_2=0.9, epsilon=1e-9\n",
+    ")\n",
+    "\n",
+    "transformer.compile(\n",
+    "    loss=masked_loss,\n",
+    "    optimizer=optimizer,\n",
+    "    metrics=[masked_accuracy, masked_aa_accuracy],\n",
+    ")\n"
+   ],
+   "id": "rMqvA-SLeVEw"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Sanity check: run a small forward pass to validate GPU graph execution\n",
+    "example_batch = next(iter(make_batches(tds, batch_size=2)))\n",
+    "example_logits = transformer(example_batch[0], training=False)\n",
+    "print(\"Logits shape:\", example_logits.shape)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "log_dir = \"logs/codon_train\"\n",
+    "tb_callback = tf.keras.callbacks.TensorBoard(\n",
+    "    log_dir=log_dir,\n",
+    "    histogram_freq=1,\n",
+    "    write_graph=True,\n",
+    "    write_images=False,\n",
+    ")\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "%load_ext tensorboard\n",
+    "%tensorboard --logdir logs/codon_train\n"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "v8Hwi2KneVEw"
+   },
+   "outputs": [],
+   "source": [
+    "train_batches = make_batches(tds)\n",
+    "val_batches = make_batches(vds)\n",
+    "\n",
+    "callback = tf.keras.callbacks.EarlyStopping(\n",
+    "    monitor='val_loss', patience=3, restore_best_weights=True, verbose=1\n",
+    ")\n",
+    "\n",
+    "history = transformer.fit(\n",
+    "    train_batches,\n",
+    "    epochs=100,\n",
+    "    validation_data=val_batches,\n",
+    "    callbacks=[callback, tb_callback],\n",
+    ")\n"
+   ],
+   "id": "v8Hwi2KneVEw"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6zD3bapJeVEw"
+   },
+   "source": [
+    "## Export\n"
+   ],
+   "id": "6zD3bapJeVEw"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "_AWYO1JqeVEw"
+   },
+   "outputs": [],
+   "source": [
+    "class Translator(tf.Module):\n",
+    "    def __init__(self, aa2id, codon2id, transformer):\n",
+    "        self.aa2id = aa2id\n",
+    "        self.codon2id = codon2id\n",
+    "        self.transformer = transformer\n",
+    "\n",
+    "    def __call__(self, sentence, max_length=max_length):\n",
+    "        sentence = tf.cast(self.aa2id(sentence), tf.int32)[tf.newaxis]\n",
+    "        encoder_input = sentence\n",
+    "        start_end = self.codon2id('<start> <end>')\n",
+    "        start = start_end[0][tf.newaxis]\n",
+    "        end = start_end[1][tf.newaxis]\n",
+    "        output_array = tf.TensorArray(dtype=tf.int32, size=0, dynamic_size=True)\n",
+    "        output_array = output_array.write(0, start)\n",
+    "        for i in tf.range(max_length):\n",
+    "            output = tf.transpose(output_array.stack())\n",
+    "            predictions = self.transformer([encoder_input, output], training=False)\n",
+    "            predictions = predictions[:, -1:, :]\n",
+    "            predicted_id = tf.argmax(predictions, axis=-1, output_type=tf.int32)\n",
+    "            output_array = output_array.write(i + 1, predicted_id[0])\n",
+    "            if tf.reduce_any(tf.equal(predicted_id, end)):\n",
+    "                break\n",
+    "        output = tf.transpose(output_array.stack())\n",
+    "        self.transformer([encoder_input, output[:, :-1]], training=False)\n",
+    "        attention_weights = self.transformer.decoder.last_attn_scores\n",
+    "        return output[0], attention_weights\n",
+    "\n",
+    "class ExportTranslator(tf.Module):\n",
+    "    def __init__(self, translator):\n",
+    "        self.translator = translator\n",
+    "\n",
+    "    @tf.function(input_signature=[tf.TensorSpec(shape=[], dtype=tf.string)])\n",
+    "    def __call__(self, sentence):\n",
+    "        result, attention_weights = self.translator(sentence, max_length=max_length)\n",
+    "        return result, attention_weights\n",
+    "\n",
+    "translator = Translator(aa2id, codon2id, transformer)\n",
+    "exporter = ExportTranslator(translator)\n",
+    "save_path = 'transformer_tf219_gpu'\n",
+    "tf.saved_model.save(exporter, save_path)\n",
+    "print(f'Saved model to {save_path}')\n"
+   ],
+   "id": "_AWYO1JqeVEw"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  },
+  "colab": {
+   "provenance": []
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide a trainer notebook that is safe and stable when running on GPUs with TensorFlow 2.19.
- Ensure consistent dtype handling to avoid graph/execution mismatches on GPU runtimes.
- Use padded batching and TF-native positional encoding for robustness with variable-length sequences.
- Add runtime checks to detect GPU availability and early graph-execution issues.

### Description
- Add new notebook `Codon_optimizer_train_tf219_gpu.ipynb` containing the full training pipeline adapted for GPU usage.
- Update install cell to pin `numpy<2.1` and add `pandas`, add GPU runtime checks, set memory growth, and call `tf.config.run_functions_eagerly(False)`.
- Switch `TextVectorization` to `output_mode="int"`/`output_dtype=tf.int32`, cast vectorized tensors to `tf.int32`, and replace batching with `.padded_batch(...)` to produce stable batches.
- Replace NumPy positional encoding with a TensorFlow implementation, make lookup tables and `TensorArray` use `int32`, add safe denominators in masked metrics, add a small forward-pass sanity check, and save the exported model to `transformer_tf219_gpu`.

### Testing
- No automated tests were executed for this change.
- The notebook includes an internal small forward-pass sanity-check cell (not executed by CI).
- The file was generated and added to the repository and committed successfully.
- Manual execution on a GPU environment is recommended to validate end-to-end training and export behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0a615c9c83279d42e61b8a29aaa7)