### PR TITLE
Remove unsupported TextVectorization `output_dtype` in TF2.19 GPU notebook

### DIFF
--- a/Codon_optimizer_train_tf219_gpu.ipynb
+++ b/Codon_optimizer_train_tf219_gpu.ipynb
@@ -240,11 +240,11 @@
     "vds = tf.data.Dataset.from_tensor_slices((val_aas, val_codons))\n",
     "\n",
     "aa2id = tf.keras.layers.TextVectorization(\n",
-    "    standardize=None, split=\"whitespace\", output_mode=\"int\", output_dtype=tf.int32\n",
+    "    standardize=None, split=\"whitespace\", output_mode=\"int\"\n",
     ")\n",
     "aa2id.adapt(tf.constant(aas))\n",
     "codon2id = tf.keras.layers.TextVectorization(\n",
-    "    standardize=None, split=\"whitespace\", output_mode=\"int\", output_dtype=tf.int32\n",
+    "    standardize=None, split=\"whitespace\", output_mode=\"int\"\n",
     ")\n",
     "codon2id.adapt(tf.constant(codons))\n"
    ],


### PR DESCRIPTION
### Motivation
- A `ValueError` occurs when constructing `TextVectorization` with the unsupported `output_dtype` keyword under the current Keras API.
- The training notebook needs to be compatible with TensorFlow/Keras 2.19 to avoid runtime errors during layer creation.

### Description
- Removed the `output_dtype` argument from `TextVectorization` calls in `Codon_optimizer_train_tf219_gpu.ipynb` so the layer is created as `tf.keras.layers.TextVectorization(standardize=None, split="whitespace", output_mode="int")`.
- The notebook already casts the layer outputs to `int32` in `prepare_batch` using `tf.cast`, so explicit `output_dtype` is unnecessary and the behavior is preserved.
- This aligns the notebook with the current Keras API and prevents the unrecognized keyword error when instantiating the layer.

### Testing
- No automated tests were run on this change.
- A commit was created updating `Codon_optimizer_train_tf219_gpu.ipynb` and no test failures are reported by automated tooling in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bf09889f483279ff2e4acdb946b85)